### PR TITLE
Geoscixyz transfer

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -155,7 +155,7 @@ numfig = True
 
 # -- Edit on Github Extension ---------------------------------------------
 
-edit_on_github_project = 'ubcgif/em'
+edit_on_github_project = 'geoscixyz/em'
 edit_on_github_branch = 'master'
 check_meta = False
 
@@ -349,7 +349,7 @@ htmlhelp_basename = 'emdoc'
 
 # -- Edit on Github Extension ---------------------------------------------
 
-edit_on_github_project = 'ubcgif/em'
+edit_on_github_project = 'geoscixyz/em'
 edit_on_github_branch = 'master'
 
 # -- Options for LaTeX output ---------------------------------------------

--- a/content/maxwell3_fdem/circuitmodel_for_eminduction/derive_response_function.rst
+++ b/content/maxwell3_fdem/circuitmodel_for_eminduction/derive_response_function.rst
@@ -103,7 +103,7 @@ Below figure shows real and imaginary component of :math:`Q`.
 
 .. plot::
 
-    from SimPEG.EM.Analytics.EMcircuit import Qfun
+    from em_examples.EMcircuit import Qfun
     import numpy as np
     import matplotlib.pyplot as plt
     L = 1.

--- a/content/maxwell3_fdem/circuitmodel_for_eminduction/index.rst
+++ b/content/maxwell3_fdem/circuitmodel_for_eminduction/index.rst
@@ -72,7 +72,7 @@ is the induction number.
 
 .. plot::
 
-    from SimPEG.EM.Analytics.EMcircuit import Qfun
+    from em_examples.EMcircuit import Qfun
     import numpy as np
     import matplotlib.pyplot as plt
     L = 1.

--- a/content/maxwell3_fdem/circuitmodel_for_eminduction/understanding_harmonicEMresponse.rst
+++ b/content/maxwell3_fdem/circuitmodel_for_eminduction/understanding_harmonicEMresponse.rst
@@ -120,7 +120,7 @@ Computed coupling coefficient along the line is shown below:
 
 .. plot::
 
-    from SimPEG.EM.Analytics.EMcircuit import Mijfun, Cfun, Qfun
+    from em_examples.EMcircuit import Mijfun, Cfun, Qfun
     import numpy as np
     import matplotlib.pyplot as plt
     L = 1.
@@ -169,7 +169,7 @@ imaginary or ampliutde and phase.
 
 .. plot::
 
-    from SimPEG.EM.Analytics.EMcircuit  import Qfun
+    from em_examples.EMcircuit  import Qfun
     import numpy as np
     import matplotlib.pyplot as plt
     L = 1.

--- a/index.rst
+++ b/index.rst
@@ -42,7 +42,7 @@ knowledge that has been acquired by practising geoscientists and, when made
 available, can elevate the learning and responsible use of electromagnetics
 throughout the communinity.
 
-.. _Github: http://github.com/ubcgif/em
+.. _Github: http://github.com/geoscixyz/em
 
 .. _what:
 
@@ -72,7 +72,7 @@ SimPEG_.
    :target: http://mybinder.org/repo/ubcgif/em_examples
    :align: center
 
-.. _Jupyter Notebooks: http://github.com/ubcgif/em_examples
+.. _Jupyter Notebooks: http://github.com/geoscixyz/em_examples
 .. _Binders: http://mybinder.org/repo/ubcgif/em_examples
 .. _SimPEG: http://simpeg.xyz
 
@@ -90,7 +90,7 @@ EM GeoSci is under construction
 .. raw:: html
 
    <div class="col-md-2" align="center">
-      <a href="http://github.com/ubcgif/em"><i class="fa fa-wrench fa-4x" aria-hidden="true"></i></a>
+      <a href="http://github.com/geoscixyz/em"><i class="fa fa-wrench fa-4x" aria-hidden="true"></i></a>
    </div>
 
 EM GeoSci is under active construction. We are working to fill in blank

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,5 +8,5 @@ properties
 sphinxcontrib-bibtex
 sphinx_rtd_theme
 Pillow
-git+git://github.com/ubcgif/em_examples.git
-git+git://github.com/simpeg/simpeg.git@analytics
+em_examples
+SimPEG

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ ipython
 ipywidgets
 sphinx==1.4.8
 matplotlib
-properties
+properties[math]
 sphinxcontrib-bibtex
 sphinx_rtd_theme
 Pillow

--- a/underconstruction.html
+++ b/underconstruction.html
@@ -8,7 +8,7 @@
         <div class="col-md-8" align="center">
             <div class="col-md-2" align="center">
                 <br>
-                <a href="http://github.com/ubcgif/em"><i class="fa fa-wrench fa-4x" aria-hidden="true"></i></a>
+                <a href="http://github.com/geoscixyz/em"><i class="fa fa-wrench fa-4x" aria-hidden="true"></i></a>
                 <br>
             </div>
             <div class="col-md-10" align="left">


### PR DESCRIPTION
- update github links to point to geoscixyz instead of ubcgif org
- use SimPEG from pip (cc @sgkang: I also had to modify your circuit model examples to import from `em_examples` instead of `SimPEG`) 
- specify that `properties[math]` is a requirement 