### PR TITLE
Update properties.rst

### DIFF
--- a/content/case_histories/lalor/properties.rst
+++ b/content/case_histories/lalor/properties.rst
@@ -9,7 +9,7 @@ The specific electrical conductivity of mineralized rocks at Lalor depends on th
 
 
 +----------------------+----------------------------+----------------------------+
-| Ore-bearing minerals | :math:`\sigma_{min}` (S/m) | :math:`\sigma_{min}` (S/m) |
+| Ore-bearing minerals | :math:`\sigma_{min}` (S/m) | :math:`\sigma_{max}` (S/m) |
 +======================+============================+============================+
 | Pyrite               | 0.003                      | 1                          |
 +----------------------+----------------------------+----------------------------+


### PR DESCRIPTION
I wonder if the table aims to show a range of variation in the conductivity [sigma_min, sigma_max].  If this is not the case, I would suggest to add a sentence saying why we see two values of \sigma_{min}.  