### PR TITLE
Update contributors.json

### DIFF
--- a/contributors.json
+++ b/contributors.json
@@ -352,7 +352,7 @@
         "location":"Vancouver, BC",
         "avatar":"https://github.com/geoscixyz/em/raw/master/images_contributors/placeholder.png"
     },
-    "eholtham":{
+    "lberan":{
         "name":"Laurens Beran",
         "affiliation":"Black Tusk Geophysics",
         "location":"Vancouver, BC",


### PR DESCRIPTION
eholtham was accidentally used twice instead of unique ID for Laurens Beran. Correction being made now.