### PR TITLE
Use geoana 0.2.1 for building the website

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -26,7 +26,6 @@ jobs:
         python -m pip install --upgrade pip
         pip install flake8 pytest
         pip install -r requirements.txt
-        pip install geoana==0.2.1
     - name: Test with pytest
       run: |
         pytest -s -v tests

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -26,6 +26,7 @@ jobs:
         python -m pip install --upgrade pip
         pip install flake8 pytest
         pip install -r requirements.txt
+        pip install geoana==0.2.1
     - name: Test with pytest
       run: |
         pytest -s -v tests

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -25,6 +25,7 @@ jobs:
       run: |
         pip list
         pip install -r requirements.txt
+        pip install geoana==0.2.1
         pip install flake8 pytest
     - name: Test with pytest
       run: |

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -23,7 +23,6 @@ jobs:
         python-version: 3.9
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
         pip install flake8 pytest
         pip install -r requirements.txt
     - name: Test with pytest

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -23,9 +23,13 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        # pip install -r requirements.txt
 
-        pip install --no-build-isolation -r requirements.txt -r requirements-build-geoana.txt
+        # Gather requirements and install older version of geoana
+        cat requirements.txt | grep -v "^geoana" > requirements-ci.txt
+        cat requirements-build-geoana.txt | grep -v "^#" >> requirements-ci.txt
+        pip install -r requirements-ci.txt
+        rm requirements-ci.txt
+        pip install --no-build-isolation geoana==0.2.1
 
         # Install extra packages
         pip install flake8 pytest

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -24,7 +24,13 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install --no-build-isolation -r requirements.txt
+        pip install -r requirements.txt
+
+        # Install build requirements for geoana 0.2.1
+        pip install numpy<1.23 setuptools<60
+        pip install --no-build-isolation geoana==0.2.1
+
+        # Install extra packages
         pip install flake8 pytest
     - name: Test with pytest
       run: |

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -23,6 +23,7 @@ jobs:
         python-version: 3.9
     - name: Install dependencies
       run: |
+        pip list
         pip install -r requirements.txt
         pip install flake8 pytest
     - name: Test with pytest

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -23,8 +23,8 @@ jobs:
         python-version: 3.9
     - name: Install dependencies
       run: |
-        pip install flake8 pytest
         pip install -r requirements.txt
+        pip install flake8 pytest
     - name: Test with pytest
       run: |
         pytest -s -v tests

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -23,9 +23,9 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install -r requirements.txt
+        # pip install -r requirements.txt
 
-        pip install --no-build-isolation geoana==0.2.1
+        pip install --no-build-isolation -r requirements.txt -r requirements-build-geoana.txt
 
         # Install extra packages
         pip install flake8 pytest

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -27,7 +27,7 @@ jobs:
         pip install -r requirements.txt
 
         # Install build requirements for geoana 0.2.1
-        pip install numpy<1.23 setuptools<60
+        pip install "numpy<1.23" "setuptools<60"
         pip install --no-build-isolation geoana==0.2.1
 
         # Install extra packages

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -25,8 +25,6 @@ jobs:
         python -m pip install --upgrade pip
         pip install -r requirements.txt
 
-        # Install build requirements for geoana 0.2.1
-        pip install "numpy<1.23" "setuptools<60"
         pip install --no-build-isolation geoana==0.2.1
 
         # Install extra packages

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -50,7 +50,14 @@ jobs:
 
     - name: Install dependencies
       run: |
-        pip install -r requirements.txt
+        python -m pip install --upgrade pip
+
+        # Gather requirements and install older version of geoana
+        cat requirements.txt | grep -v "^geoana" > requirements-ci.txt
+        cat requirements-build-geoana.txt | grep -v "^#" >> requirements-ci.txt
+        pip install -r requirements-ci.txt
+        rm requirements-ci.txt
+        pip install --no-build-isolation geoana==0.2.1
 
     - name: Build pages
       run: |

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -23,9 +23,8 @@ jobs:
         python-version: 3.9
     - name: Install dependencies
       run: |
-        pip list
-        pip install -r requirements.txt
-        pip install geoana==0.2.1
+        python -m pip install --upgrade pip
+        pip install --no-build-isolation -r requirements.txt
         pip install flake8 pytest
     - name: Test with pytest
       run: |

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -43,7 +43,6 @@ jobs:
 
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
         pip install -r requirements.txt
 
     - name: Build pages

--- a/requirements-build-geoana.txt
+++ b/requirements-build-geoana.txt
@@ -1,0 +1,13 @@
+# Requirements to build geoana 0.2.1 without isolation
+#
+# This file was added as a way to install geoana 0.2.1 (old version) in GitHub
+# Actions and build the website using an this old version of geoana.
+#
+# We should remove this file after updating the repo to work with the latest
+# version of geoana. The easiest way to do so would be to revert the commit
+# that added this file.
+#
+numpy<1.23
+cython
+setuptools<60
+wheel

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,4 @@ sphinxcontrib-bibtex
 sphinx_rtd_theme
 pytest
 matplotlib
-geoana==0.1.3
-setuptools <65 # needed to pin geoana to 0.1.3
+geoana==0.2.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,4 @@ sphinxcontrib-bibtex
 sphinx_rtd_theme
 pytest
 matplotlib
-numpy<1.23
-geoana==0.2.1
-setuptools<60
+# geoana==0.2.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ matplotlib
 numpy<1.23
 cython
 setuptools<60
+wheel

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ sphinx_rtd_theme
 pytest
 matplotlib
 geoana==0.1.3
+setuptools <65 # needed to pin geoana to 0.1.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,3 @@ sphinx_rtd_theme
 pytest
 matplotlib
 geoana==0.2.1
-setuptools < 60.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ sphinxcontrib-bibtex
 sphinx_rtd_theme
 pytest
 matplotlib
-geoana==0.2.1
+geoana

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,6 @@ sphinxcontrib-bibtex
 sphinx_rtd_theme
 pytest
 matplotlib
+numpy<1.23
 geoana==0.2.1
 setuptools<60

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ sphinxcontrib-bibtex
 sphinx_rtd_theme
 pytest
 matplotlib
-geoana
+geoana==0.2.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ sphinxcontrib-bibtex
 sphinx_rtd_theme
 pytest
 matplotlib
-geoana
+geoana==0.1.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,5 @@ sphinxcontrib-bibtex
 sphinx_rtd_theme
 pytest
 matplotlib
-geoana==0.2.1
+# geoana==0.2.1
 setuptools>64

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,8 +3,4 @@ sphinxcontrib-bibtex
 sphinx_rtd_theme
 pytest
 matplotlib
-# geoana==0.2.1
-numpy<1.23
-cython
-setuptools<60
-wheel
+geoana==0.2.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,4 @@ sphinxcontrib-bibtex
 sphinx_rtd_theme
 pytest
 matplotlib
-geoana==0.2.1
-setuptools < 60.0
+# geoana

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,5 @@ pytest
 matplotlib
 # geoana==0.2.1
 numpy<1.23
-cython==0.29
+cython
 setuptools<60

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,5 @@ sphinxcontrib-bibtex
 sphinx_rtd_theme
 pytest
 matplotlib
-# geoana==0.2.1
-setuptools>64
+geoana==0.2.1
+setuptools<60

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ sphinx_rtd_theme
 pytest
 matplotlib
 geoana==0.2.1
+setuptools < 60.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ sphinx_rtd_theme
 pytest
 matplotlib
 geoana==0.2.1
-setuptools==0.60
+setuptools>64

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ sphinx_rtd_theme
 pytest
 matplotlib
 geoana==0.2.1
+setuptools==0.60

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,6 @@ sphinx_rtd_theme
 pytest
 matplotlib
 # geoana==0.2.1
+numpy<1.23
+cython==0.29
+setuptools<60

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,5 @@ sphinxcontrib-bibtex
 sphinx_rtd_theme
 pytest
 matplotlib
-# geoana
+geoana==0.2.1
+setuptools < 60.0


### PR DESCRIPTION
Use an older version of geoana to build the website to avoid errors coming from incompatibilities with the latest version. Install `geoana==0.2.1` in GitHub Actions to run tests and to build the website. Just pinning it in the `requirements.txt` file doesn't work because of missing build dependencies for that old version. So the build requirements (listed in a new `requirements-build-geoana.txt` file) are installed along with other needed packages (e.g. Sphinx), and `geoana=0.2.1` gets installed with `pip` but disabling the build isolation (passing `--no-build-isolation`).

This fix is just a patch, we should make the repo compatible with latest geoana at some point. By then, we should revert these changes.