### PR TITLE
Avoid duplicated Actions runs and deploy only from main

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -52,6 +52,10 @@ jobs:
         python _ext/copy_images.py
 
     - name: GitHub Pages
+      # Only deploy if the event that triggered was a push to main
+      # (only pushes to main triggers builds, see 'on' condition in the
+      # beginning of the file)
+      if: success() && github.event_name == 'push'
       uses: crazy-max/ghaction-github-pages@v2.5.0
       with:
         build_dir: _build/html

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -4,11 +4,10 @@
 name: EM Website Build
 
 on:
+  pull_request:
   push:
     branches:
-      - '*'
-  pull_request:
-    branches: [ main ]
+      - main
 
 jobs:
   test:


### PR DESCRIPTION
Update run conditions for GitHub Actions. Run GitHub Actions on every Pull Request and only on pushes to `main` branch. This avoids having duplicated runs in every PR: one because it's a PR and one because it's a push to a branch. Add condition to deploy GitHub Pages only if the built came from a push to `main`.
