### PR TITLE
Pin geoana==0.1.3

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -29,7 +29,7 @@ jobs:
         cat requirements-build-geoana.txt | grep -v "^#" >> requirements-ci.txt
         pip install -r requirements-ci.txt
         rm requirements-ci.txt
-        pip install --no-build-isolation geoana==0.2.1
+        pip install --no-build-isolation geoana==0.1.3
 
         # Install extra packages
         pip install flake8 pytest
@@ -57,7 +57,7 @@ jobs:
         cat requirements-build-geoana.txt | grep -v "^#" >> requirements-ci.txt
         pip install -r requirements-ci.txt
         rm requirements-ci.txt
-        pip install --no-build-isolation geoana==0.2.1
+        pip install --no-build-isolation geoana==0.1.3
 
     - name: Build pages
       run: |

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ sphinxcontrib-bibtex
 sphinx_rtd_theme
 pytest
 matplotlib
-geoana==0.2.1
+geoana==0.1.3


### PR DESCRIPTION
Use geoana==0.1.3 instead of 0.2.1. The latter had an issue with circular imports that made building the website to fail.

This change (along with #579) should be also reverted when updating the repo to work with the latest version of geoana.
